### PR TITLE
add endpoints for cryptocurrency and company data retrieval

### DIFF
--- a/Controllers/TradingViewController.cs
+++ b/Controllers/TradingViewController.cs
@@ -16,11 +16,27 @@ namespace vueChain.Controllers
             _tradingViewService = tradingViewService;
         }
 
-        [HttpGet("data")]
+        [HttpGet("bolsa")]
         [Authorize]
         public async Task<IActionResult> GetTradingViewData()
         {
             var data = await _tradingViewService.GetTradingViewDataAsync();
+            return Content(data, "application/javascript");
+        }
+        
+        [HttpGet("cripto-currency")]
+        [Authorize]
+        public async Task<IActionResult> GetCriptoCurrency()
+        {
+            var data = await _tradingViewService.GetCriptoCurrency();
+            return Content(data, "application/javascript");
+        }
+        
+        [HttpGet("get-companies")]
+        [Authorize]
+        public async Task<IActionResult>GetCompanies()
+        {
+            var data = await _tradingViewService.GetCompanies();
             return Content(data, "application/javascript");
         }
     }

--- a/interfaces/ITradingViewService.cs
+++ b/interfaces/ITradingViewService.cs
@@ -3,5 +3,9 @@ namespace vueChain.Interfaces
     public interface ITradingViewService
     {
         Task<string> GetTradingViewDataAsync();
+        Task<string> GetCriptoCurrency();
+
+        Task<string>  GetCompanies();
+
     }
 }

--- a/services/TradingViewService.cs
+++ b/services/TradingViewService.cs
@@ -19,5 +19,20 @@ namespace vueChain.Services
             var response = await _httpClient.GetStringAsync(url);
             return response;
         }
+        public async Task<string> GetCriptoCurrency()
+        {
+            string url = "https://s3.tradingview.com/external-embedding/embed-widget-screener.js";
+            var response = await _httpClient.GetStringAsync(url);
+            return response;
+        }
+        
+        public async Task<string> GetCompanies()
+        {
+            string url = "https://s3.tradingview.com/external-embedding/embed-widget-symbol-overview.js";
+            var response = await _httpClient.GetStringAsync(url);
+            return response;
+        }
+        
+        
     }
 }


### PR DESCRIPTION
This pull request introduces new endpoints to the `TradingViewController` and updates the corresponding service interface and implementation to support these endpoints. The most important changes include adding new methods to fetch cryptocurrency and company data, and modifying existing endpoint routes.

New endpoints and methods:

* [`Controllers/TradingViewController.cs`](diffhunk://#diff-b9be8a537fdffd8aa14bdb34f65e245e9a49f47cb6ea09335b461d077fa76c9bL19-R41): Added new endpoints `GetCriptoCurrency` and `GetCompanies` to fetch cryptocurrency and company data, respectively. Also, modified the existing endpoint route from "data" to "bolsa".
* [`interfaces/ITradingViewService.cs`](diffhunk://#diff-50f2bc2772259c1605c817303e4957eda1b0725b4ea42c5cd6f9cc29b8cac954R6-R9): Added new method signatures `GetCriptoCurrency` and `GetCompanies` to the `ITradingViewService` interface.
* [`services/TradingViewService.cs`](diffhunk://#diff-30c65ab7052e7a604110db71c10d3e8be828506fbdbda813875c3fb9b9a3fc42R22-R36): Implemented the new methods `GetCriptoCurrency` and `GetCompanies` to fetch data from specific URLs.